### PR TITLE
Fix/ingest timeout

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -105,7 +105,7 @@ assemblyMergeStrategy in assembly := {
 // Settings from sbt-lighter plugin that will automate creating and submitting this job to EMR
 import sbtlighter._
 
-sparkEmrRelease := "emr-5.13.0"
+sparkEmrRelease := "emr-5.20.0"
 sparkAwsRegion := "us-east-1"
 sparkEmrApplications := Seq("Spark", "Zeppelin", "Ganglia")
 sparkEmrBootstrap := List(BootstrapAction("Install GDAL + dependencies",
@@ -123,7 +123,7 @@ sparkCoreEbsSize := Some(800)
 sparkMasterEbsSize := Some(200)
 
 //Cluster name
-sparkClusterName := s"geotrellis-calTest"
+sparkClusterName := s"geotrellis-calTest - echeipesh"
 sparkEmrServiceRole := "EMR_DefaultRole"
 sparkInstanceRole := "EMR_EC2_DefaultRole"
 sparkJobFlowInstancesConfig := sparkJobFlowInstancesConfig.value.withEc2KeyName(
@@ -144,7 +144,7 @@ sparkEmrConfigs := List(
     "spark.default.parallelism" -> "960", //Testing 960 partitions for 106 Grids at ~2GB/grid slawler
     "spark.rdd.compress" -> "true",
     "spark.driver.extraJavaOptions" -> "-Djava.library.path=/usr/local/lib",
-    "spark.executor.extraJavaOptions" -> "-XX:+UseParallelGC -Dgeotrellis.s3.threads.rdd.write=64 -Djava.library.path=/usr/local/lib",
+    "spark.executor.extraJavaOptions" -> "-XX:+UseParallelGC -Djava.library.path=/usr/local/lib",
     "spark.executorEnv.LD_LIBRARY_PATH" -> "/usr/local/lib"
   ),
   EmrConfig("spark-env").withProperties(


### PR DESCRIPTION
Looked at S3 client timeout settings because of this error:

```
java.net.SocketTimeoutException: Read timed out
        at java.net.SocketInputStream.socketRead0(Native Method)
        at java.net.SocketInputStream.socketRead(SocketInputStream.java:116)
        at java.net.SocketInputStream.read(SocketInputStream.java:171)
        at java.net.SocketInputStream.read(SocketInputStream.java:141)
        at sun.security.ssl.InputRecord.readFully(InputRecord.java:465)
        at sun.security.ssl.InputRecord.readV3Record(InputRecord.java:593)
        at sun.security.ssl.InputRecord.read(InputRecord.java:532)
        at sun.security.ssl.SSLSocketImpl.readRecord(SSLSocketImpl.java:983)
        at sun.security.ssl.SSLSocketImpl.readDataRecord(SSLSocketImpl.java:940)
        at sun.security.ssl.AppInputStream.read(AppInputStream.java:105)
        at org.apache.http.impl.io.SessionInputBufferImpl.streamRead(SessionInputBufferImpl.java:139)
        at org.apache.http.impl.io.SessionInputBufferImpl.read(SessionInputBufferImpl.java:200)
        at org.apache.http.impl.io.ContentLengthInputStream.read(ContentLengthInputStream.java:178)
        at org.apache.http.conn.EofSensorInputStream.read(EofSensorInputStream.java:135)
        at com.amazonaws.internal.SdkFilterInputStream.read(SdkFilterInputStream.java:82)
        at com.amazonaws.event.ProgressInputStream.read(ProgressInputStream.java:180)
        at com.amazonaws.internal.SdkFilterInputStream.read(SdkFilterInputStream.java:82)
        at com.amazonaws.services.s3.internal.S3AbortableInputStream.read(S3AbortableInputStream.java:125)
        at com.amazonaws.internal.SdkFilterInputStream.read(SdkFilterInputStream.java:82)
        at com.amazonaws.internal.SdkFilterInputStream.read(SdkFilterInputStream.java:82)
        at com.amazonaws.internal.SdkFilterInputStream.read(SdkFilterInputStream.java:82)
        at com.amazonaws.event.ProgressInputStream.read(ProgressInputStream.java:180)
        at com.amazonaws.internal.SdkFilterInputStream.read(SdkFilterInputStream.java:82)
        at com.amazonaws.util.LengthCheckInputStream.read(LengthCheckInputStream.java:107)
        at com.amazonaws.internal.SdkFilterInputStream.read(SdkFilterInputStream.java:82)
        at java.io.FilterInputStream.read(FilterInputStream.java:107)
        at org.apache.commons.io.IOUtils.copyLarge(IOUtils.java:1792)
        at org.apache.commons.io.IOUtils.copyLarge(IOUtils.java:1769)
        at org.apache.commons.io.IOUtils.copy(IOUtils.java:1744)
        at org.apache.commons.io.IOUtils.toByteArray(IOUtils.java:462)
        at geotrellis.spark.io.s3.AmazonS3Client.readRange(AmazonS3Client.scala:110)
        at geotrellis.spark.io.s3.util.S3RangeReader.readClippedRange(S3RangeReader.scala:45)
        at geotrellis.util.RangeReader$class.readRange(RangeReader.scala:36)
        at geotrellis.spark.io.s3.util.S3RangeReader.readRange(S3RangeReader.scala:35)
        at geotrellis.util.StreamingByteReader.readChunk(StreamingByteReader.scala:99)
        at geotrellis.util.StreamingByteReader.ensureChunk(StreamingByteReader.scala:110)
        at geotrellis.util.StreamingByteReader.getBytes(StreamingByteReader.scala:118)
        at geotrellis.raster.io.geotiff.LazySegmentBytes.getBytes(LazySegmentBytes.scala:120)
        at geotrellis.raster.io.geotiff.LazySegmentBytes$$anonfun$readChunk$1.apply(LazySegmentBytes.scala:99)
        at geotrellis.raster.io.geotiff.LazySegmentBytes$$anonfun$readChunk$1.apply(LazySegmentBytes.scala:97)
        at scala.collection.immutable.List.map(List.scala:277)
        at geotrellis.raster.io.geotiff.LazySegmentBytes.readChunk(LazySegmentBytes.scala:97)
        at geotrellis.raster.io.geotiff.LazySegmentBytes$$anonfun$getSegments$1.apply(LazySegmentBytes.scala:115)
        at geotrellis.raster.io.geotiff.LazySegmentBytes$$anonfun$getSegments$1.apply(LazySegmentBytes.scala:115)
        at scala.collection.Iterator$$anon$12.nextCur(Iterator.scala:434)
        at scala.collection.Iterator$$anon$12.hasNext(Iterator.scala:440)
```

in cluser `j-1I73KDREQVPFE`
file: `containers/application_1557675770746_0001/container_1557675770746_0001_01_000032/stderr.gz`

Ran `usbuildings.MainIngestData` with default inputs to write `s3://dewberry-demo/testingests/` layer `dem_10m_10m_region4` at zoom 14

<img width="1069" alt="Screen Shot 2019-05-13 at 2 32 24 PM" src="https://user-images.githubusercontent.com/1158084/57646183-fdc69800-758d-11e9-949f-10ae6056d638.png">
