### PR TITLE
Fix: FeatureSummaryRDD works over MultibandTile layers

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.15.0"
+version in ThisBuild := "0.16.0"


### PR DESCRIPTION
The caller at BuildingSummaryApp gets to decide how to use all the bands for one summary. Currently we just use the first band to make histogram.

When using with layers ingested into `s3://dewberry-demo/geotl_prod` the mismatched was logged with:

```
BuildingSummaryApp: Found geotrellis.raster.ArrayMultibandTile, expecting union. This can be caused by using a type parameter which doesn't match the object being deserialized.
```